### PR TITLE
develop브랜치에 각종 버그를 해결합니다~~

### DIFF
--- a/Assets/Prefabs/Enemies/BaseEnemies/Archer/Archer.prefab
+++ b/Assets/Prefabs/Enemies/BaseEnemies/Archer/Archer.prefab
@@ -144,8 +144,7 @@ MonoBehaviour:
   WaitForMoveMax: 0.8
   HalfMoveRangeX: 2.5
   HalfMoveRangeY: 0
-  Range: 1
-  OriginPosition: {x: 0, y: 0}
+  OriginPosition: {x: 0, y: 0.87}
   MoveSmooth: 0.3
   RangeOffset: 0.31
   AbilityTable: {fileID: 2652715522410420987}

--- a/Assets/Prefabs/Enemies/BaseEnemies/Scarecrow.prefab
+++ b/Assets/Prefabs/Enemies/BaseEnemies/Scarecrow.prefab
@@ -45,12 +45,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _JsonTableName: CharacterAbility
   _JsonLableName: Scarecrow
-  _MoveSpeed: 1
-  _MaxHealth: 1
-  _AttackPower: 1
-  _AttackDelay: 0
-  _BeginAttackDelay: 1
-  _AfterAttackDelay: 1
 --- !u!1 &6949924797478406765
 GameObject:
   m_ObjectHideFlags: 0
@@ -199,8 +193,7 @@ MonoBehaviour:
   WaitForMoveMax: 0.8
   HalfMoveRangeX: 2.5
   HalfMoveRangeY: 0
-  Range: 0
-  OriginPosition: {x: 0, y: 0}
+  OriginPosition: {x: 0, y: 0.87}
   MoveSmooth: 0.3
   RangeOffset: 0.31
   AbilityTable: {fileID: 412821576838472771}

--- a/Assets/Prefabs/Enemies/Goblins/Dart.prefab
+++ b/Assets/Prefabs/Enemies/Goblins/Dart.prefab
@@ -82,5 +82,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Dart
       objectReference: {fileID: 0}
+    - target: {fileID: 9221226311051328735, guid: 590da96b43019814bb83719c476358bb,
+        type: 3}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 590da96b43019814bb83719c476358bb, type: 3}

--- a/Assets/Prefabs/Enemies/Goblins/Goblin.prefab
+++ b/Assets/Prefabs/Enemies/Goblins/Goblin.prefab
@@ -47,6 +47,11 @@ PrefabInstance:
       propertyPath: mWaitForMoveMax
       value: 0.6
       objectReference: {fileID: 0}
+    - target: {fileID: 6949924797478406736, guid: 7a5c4cb44c7c4f84caae8c93a28361e5,
+        type: 3}
+      propertyPath: OriginPosition.y
+      value: 0.87
+      objectReference: {fileID: 0}
     - target: {fileID: 6949924797478406764, guid: 7a5c4cb44c7c4f84caae8c93a28361e5,
         type: 3}
       propertyPath: m_Color.r

--- a/Assets/Prefabs/Enemies/Goblins/GoblinAssassin.prefab
+++ b/Assets/Prefabs/Enemies/Goblins/GoblinAssassin.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7607163599574314350}
   m_Layer: 0
   m_Name: GoblinAssassin
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -99,8 +99,7 @@ MonoBehaviour:
   WaitForMoveMax: 0.5
   HalfMoveRangeX: 2.5
   HalfMoveRangeY: 0
-  Range: 5
-  OriginPosition: {x: 0, y: 0}
+  OriginPosition: {x: 0, y: 0.87}
   MoveSmooth: 0.3
   RangeOffset: 0.31
   AbilityTable: {fileID: 7274113786828326568}

--- a/Assets/Prefabs/Enemies/Goblins/GoblinChief.prefab
+++ b/Assets/Prefabs/Enemies/Goblins/GoblinChief.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 2359955915055407551}
   m_Layer: 0
   m_Name: GoblinChief
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -99,8 +99,7 @@ MonoBehaviour:
   WaitForMoveMax: 0.5
   HalfMoveRangeX: 2.5
   HalfMoveRangeY: 6
-  Range: 2
-  OriginPosition: {x: 0, y: 0}
+  OriginPosition: {x: 0, y: 1.2}
   MoveSmooth: 0.3
   RangeOffset: 0.31
   AbilityTable: {fileID: 2624679047327443531}

--- a/Assets/Prefabs/Enemies/Goblins/GoblinDart.prefab
+++ b/Assets/Prefabs/Enemies/Goblins/GoblinDart.prefab
@@ -97,6 +97,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: GoblinDart
       objectReference: {fileID: 0}
+    - target: {fileID: 2652715524362353820, guid: bd722090c4bf3764abcd77553806ce1b,
+        type: 3}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
     - target: {fileID: 2652715524362353823, guid: bd722090c4bf3764abcd77553806ce1b,
         type: 3}
       propertyPath: mArrow

--- a/Assets/Prefabs/Enemies/Goblins/GoblinShaman.prefab
+++ b/Assets/Prefabs/Enemies/Goblins/GoblinShaman.prefab
@@ -58,6 +58,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: GoblinShaman
       objectReference: {fileID: 0}
+    - target: {fileID: 6112597578512421609, guid: 8f64a3f39f88d504f82f46cb3a71e3d5,
+        type: 3}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
     - target: {fileID: 6112597578512421610, guid: 8f64a3f39f88d504f82f46cb3a71e3d5,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -128,6 +133,11 @@ PrefabInstance:
         type: 3}
       propertyPath: Range
       value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6112597578512421611, guid: 8f64a3f39f88d504f82f46cb3a71e3d5,
+        type: 3}
+      propertyPath: OriginPosition.y
+      value: 0.87
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8f64a3f39f88d504f82f46cb3a71e3d5, type: 3}

--- a/Assets/Prefabs/Enemies/Totems/BombTotem.prefab
+++ b/Assets/Prefabs/Enemies/Totems/BombTotem.prefab
@@ -58,7 +58,7 @@ GameObject:
   - component: {fileID: 1309640331586953153}
   m_Layer: 0
   m_Name: BombTotem
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Enemies/Totems/Buff Totem.prefab
+++ b/Assets/Prefabs/Enemies/Totems/Buff Totem.prefab
@@ -100,7 +100,7 @@ GameObject:
   - component: {fileID: 53926453361515183}
   m_Layer: 0
   m_Name: Buff Totem
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Enemies/Totems/CrossTotem.prefab
+++ b/Assets/Prefabs/Enemies/Totems/CrossTotem.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 4431225368971025645}
   m_Layer: 0
   m_Name: CrossTotem
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Enemies/Totems/SuicideTotem.prefab
+++ b/Assets/Prefabs/Enemies/Totems/SuicideTotem.prefab
@@ -90,7 +90,7 @@ GameObject:
   - component: {fileID: 1665258982211995878}
   m_Layer: 0
   m_Name: SuicideTotem
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Enemies/Totems/TotemLighting/LightingTotem.prefab
+++ b/Assets/Prefabs/Enemies/Totems/TotemLighting/LightingTotem.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 2384636422650176517}
   m_Layer: 0
   m_Name: LightingTotem
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Enemies/Totems/XShapeTotem.prefab
+++ b/Assets/Prefabs/Enemies/Totems/XShapeTotem.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 4431225368971025645}
   m_Layer: 0
   m_Name: XShapeTotem
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -370,8 +370,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mGameOverWindow: {fileID: 2097570444}
   mBlinkTime: 0.2
-  WaitTimeATK: 0.8
-  mMoveSpeed: 4
   RangeArea: {fileID: 2055968785}
   AbilityTable: {fileID: 1250011945}
   mDefense: 10000
@@ -423,6 +421,75 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
+--- !u!1001 &988303094
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444841, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836244618479444843, guid: a7a430e2c32c33a4a90ed8cd771529d9,
+        type: 3}
+      propertyPath: m_Name
+      value: GoogleSheetData
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7a430e2c32c33a4a90ed8cd771529d9, type: 3}
 --- !u!1 &1250011944
 GameObject:
   m_ObjectHideFlags: 0
@@ -452,11 +519,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6737ae96f0551d146a948e27dee5d1eb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _MoveSpeed: 1
-  _MaxHealth: 1000
-  _AttackPower: 1
-  _BeginAttackDelay: 1
-  _AfterAttackDelay: 1
+  _JsonTableName: CharacterAbility
+  _JsonLableName: Player
 --- !u!4 &1250011946
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemies/BaseEnemies/Archer/Arrow.cs
+++ b/Assets/Scripts/Enemies/BaseEnemies/Archer/Arrow.cs
@@ -46,7 +46,8 @@ public class Arrow : MonoBehaviour
 
     private void OnEnable()
     {
-        mEnterCount = 0;
+        mEnterCount = 0; 
+        mCanDestroy = mCanDestroy ?? (o => false);
 
         StartCoroutine(EUpdate());
     }

--- a/Assets/Scripts/Enemies/Totems/BombTotem.cs
+++ b/Assets/Scripts/Enemies/Totems/BombTotem.cs
@@ -80,7 +80,7 @@ public class BombTotem : MonoBehaviour, IObject, ICombatable
 
     public void Damaged(float damage, GameObject attacker)
     {
-        gameObject.SetActive((AbilityTable.Table[Ability.CurHealth] -= damage) <= 0f);
+        gameObject.SetActive((AbilityTable.Table[Ability.CurHealth] -= damage) > 0f);
     }
 
     public void CastBuff(BUFF buffType, IEnumerator castedBuff)

--- a/Assets/Scripts/General/Player.cs
+++ b/Assets/Scripts/General/Player.cs
@@ -147,6 +147,8 @@ public class Player : MonoBehaviour, ICombatable
             {
                 case LPOSITION3.TOP:
                     mCanElevation = Castle.Instance.CanNextPoint();
+
+                    moveDir9 = mLocation9;
                     break;
 
                 case LPOSITION3.MID:
@@ -209,7 +211,7 @@ public class Player : MonoBehaviour, ICombatable
 
     private void MoveAction(DIRECTION9 moveDIR9)
     {
-        if (mEMove == null && moveDIR9 != mLocation9)
+        if (mEMove == null)
         {
             if (mCanElevation)
             {

--- a/Assets/Scripts/Modules/Area.cs
+++ b/Assets/Scripts/Modules/Area.cs
@@ -46,7 +46,7 @@ public class Area : MonoBehaviour
     {
         mSenseList.Remove(collision.gameObject);
 
-        if (mSenseList.Count.Equals(0)) mEmptyAction.Invoke();
+        if (mSenseList.Count.Equals(0)) mEmptyAction?.Invoke();
     }
     public bool TryEnterTypeT<T>(out T enterObject) where T : class
     {

--- a/Assets/Scripts/Singletons/BuffLibrary.cs
+++ b/Assets/Scripts/Singletons/BuffLibrary.cs
@@ -23,20 +23,20 @@ public class BuffLibrary : Singleton<BuffLibrary>
    
     private IEnumerable SpeedUpBuff(float durate, uint level, AbilityTable ability)
     {
-        ability.Table[Ability.IMoveSpeed] += ability.MoveSpeed * level * SPEEDUP;
+        float increment = ability.Table[Ability.MoveSpeed] * level * SPEEDUP;
 
+        ability.Table[Ability.IMoveSpeed] += increment;
         for (float i = 0; i < durate; i += DeltaTime) { yield return null; }
-
-        ability.Table[Ability.IMoveSpeed] -= ability.MoveSpeed * level * SPEEDUP;
+        ability.Table[Ability.IMoveSpeed] -= increment;
     }
   
     private IEnumerable PowerBoostBuff(float durate, uint level, AbilityTable ability)
     {
-        ability.Table[Ability.IAttackPower] += ability.AttackPower * level * POWER_BOOST;
+        float increment = ability.Table[Ability.AttackPower] * level * SPEEDUP;
 
+        ability.Table[Ability.IAttackPower] += increment;
         for (float i = 0; i < durate; i += DeltaTime) { yield return null; }
-
-        ability.Table[Ability.IAttackPower] -= ability.AttackPower * level * POWER_BOOST;
+        ability.Table[Ability.IAttackPower] -= increment;
     }
     
     #region READ


### PR DESCRIPTION
> ***Arrow와 Archer가 사용하는 대리자의 NullReference...오류를 수정한다***
- `Action`대리자의 경우, 대리자가 `null`인지를 확인한 뒤 대리자를 실행하도록 한다.
- `Func`대리자의 경우, 대리자가 `null`인 경우 일반적인 상태를 유지하는 값을 반환하도록 설정한다.
Arrow 대리자 `mCanDestroy`가 이 경우에 해당한다.

> ***SampleScene의 NullReference...오류를 수정한다***
- `Player`객체의 경우, 발생시키는 오류의 원인인 `TableLable`의 값을 할당한다.
- `Scarecrow`객체가 발생시키는 오류의 원인을 해결하기 위해, `GoolgeSheetData`프리팹을 씬에 배치한다.

> ***버프를 적용받은 개체의 능력치가 엉뚱하게 상승하고, 증감하던 버그를 수정한다***
- 이 버그의 원인은 원래 능력치의 증감을 적용시키는 방식이 아닌, 증감치까지 계산된 능력치에 증감을 적용시켰기 때문이다.
이를 해결하기위해, 버프가 원래 능력치에 증감치를 적용시키도록 한다.

- BombTotem의 사망 로직이 올바르게 작동하지않던 버그를 수정한다.
- 플레이어의 승강 이동 버그를 수정한다.