### PR TITLE
상하 이동이 끝난 뒤에 공격이 발생하는 버그를 해결한다

### DIFF
--- a/Assets/Scripts/Player/Controller/TouchController/TouchController.cs
+++ b/Assets/Scripts/Player/Controller/TouchController/TouchController.cs
@@ -149,12 +149,13 @@ public class TouchController : MonoBehaviour
 
                                     if (direction.y > 0)
                                     {
-                                        _Player.MoveOrder(Direction.Up);
+                                        _MoveRoutine.StartRoutine(Move(Direction.Up));
                                     }
                                     else
                                     {
-                                        _Player.MoveOrder(Direction.Down);
+                                        _MoveRoutine.StartRoutine(Move(Direction.Down));
                                     }
+                                    _StationaryTime = 0f;
                                 }
                             }
                         }
@@ -231,8 +232,6 @@ public class TouchController : MonoBehaviour
 #endif
         _Player.MoveStop();
         _MoveRoutine.Finish();
-
-        _StationaryTime = 0f;
     }
     private void OnDisable()
     {

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -467,8 +467,6 @@ public class Player : MonoBehaviour, ICombatable
     }
     private IEnumerator MoveWithPoint(Vector3 movePoint, Direction direction)
     {
-        yield return StartCoroutine(MoveWithPoint(movePoint));
-
         switch (direction)
         {
             case Direction.Up:
@@ -484,6 +482,7 @@ public class Player : MonoBehaviour, ICombatable
                 mLocation9--;
                 break;
         }
+        yield return StartCoroutine(MoveWithPoint(movePoint));
     }
 
     public void InputLock(bool isLock) {


### PR DESCRIPTION
버그의 원인은 상하 이동은 MoveRoutine을 사용하지 않기 때문이었다.
MoveRoutine을 사용하지 않기 때문에 MoveRoutine은 끝난 상태였고, 그렇기 때문에 TouchPhase가 Stationary로 돌아오자마자 공격을 실행할 수 있었던 것이다.

또한 플레이어의 mLocation9의 값은 이동이 이루어지기 전에 값을 변경하여, 플레이어의 위치를 올바르게 기록하도록 한다.