### PR TITLE
스와이프 조작의 상하이동이 엉뚱한 지점에서 멈추는 버그를 해결한다

### DIFF
--- a/Assets/Scripts/Player/Controller/TouchController/TouchController.cs
+++ b/Assets/Scripts/Player/Controller/TouchController/TouchController.cs
@@ -219,17 +219,38 @@ public class TouchController : MonoBehaviour
     private IEnumerator Move(Direction direction)
     {
         _Player.MoveOrder(direction);
+
+        switch (direction)
+        {
+            case Direction.Up:
+            case Direction.Down:
+                {
+                    while (_Player.IsMoving())
+                    {
+                        yield return null;
+                    }
+                }
+                break;
+            case Direction.Right:
+            case Direction.Left:
+                {
 #if UNITY_EDITOR
-        while (!Input.GetMouseButtonUp(0))
-        {
-            yield return null;
-        }
+                    while (!Input.GetMouseButtonUp(0))
+                    {
+                        yield return null;
+                    }
 #else
-        while (Input.touchCount > 0) 
-        {
-            yield return null; 
-        }
+                    while (Input.touchCount > 0)
+                    {
+                        yield return null;
+                    }
 #endif
+                }
+                break;
+            default:
+                yield return null;
+                break;
+        }
         _Player.MoveStop();
         _MoveRoutine.Finish();
     }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -315,6 +315,10 @@ public class Player : MonoBehaviour, ICombatable
         DeathEvent?.Invoke(false);
     }
 
+    public bool IsMoving()
+    {
+        return !_MoveRoutine.IsFinished();
+    }
     public void MoveStop()
     {
         _MoveRoutine.StopRoutine();


### PR DESCRIPTION
버그의 원인은 상하이동을 중단시키는 조건이 좌우이동에 맞춰져있었기 때문이었다.

이동하는 방향에 따라 이동을 중단시키는 조건을 다르게하여, 버그를 해결한다.
이를 위해 플레이어는 현재 이동중인지를 반환하는 함수, IsMoving을 구현하도록 한다.